### PR TITLE
Add config.json creation if not found

### DIFF
--- a/main.py
+++ b/main.py
@@ -238,6 +238,18 @@ class SpotifyAlbumAnalyzer(QMainWindow):
         else:
             logging.warning("config.json not found. Telegram submission will not work.")
             QMessageBox.warning(self, "Configuration Missing", "config.json not found. Telegram submission will not work.")
+            # Create config.json from template
+            template_path = resource_path('config_template.json')
+            try:
+                with open(template_path, 'r') as template_file:
+                    default_config = json.load(template_file)
+                with open(config_path, 'w') as config_file:
+                    json.dump(default_config, config_file, indent=4)
+                logging.info("Default config.json created from template.")
+                QMessageBox.information(self, "Configuration Created", "Default config.json created from template.")
+            except Exception as e:
+                logging.error(f"Failed to create default config.json: {e}")
+                QMessageBox.critical(self, "Configuration Error", f"Failed to create default config.json: {e}")
 
     def check_for_updates(self):
         if not all([self.github_token, self.github_owner, self.github_repo]):

--- a/main.py
+++ b/main.py
@@ -116,6 +116,7 @@ class SpotifyAlbumAnalyzer(QMainWindow):
         self.chat_id = None
         self.message_thread_id = None
         self.dataChanged = False
+        self.github_token = None  # Initialize github_token attribute
 
         # Initialize search-related variables
         self.matches = []


### PR DESCRIPTION
Update `main.py` to create `config.json` if not found and notify the user.

* Modify the `load_config` method to create `config.json` from `config_template.json` if it is missing.
* Add a message box to notify the user about the creation of `config.json`.
* Log the creation of the default `config.json` file.
* Handle exceptions during the creation of `config.json` and notify the user if an error occurs.

