### PR TITLE
Add genre submit option to Edit menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ import subprocess
 
 # Import worker classes from workers.py
 
-from dialogs import HelpDialog, LogViewerDialog, ManualAddAlbumDialog, SubmitDialog, UpdateDialog
+from dialogs import HelpDialog, LogViewerDialog, ManualAddAlbumDialog, SubmitDialog, UpdateDialog, GenreSubmitDialog
 from workers import DownloadWorker, SubmitWorker, Worker
 from image_handler import ImageWidget
 
@@ -462,6 +462,11 @@ class SpotifyAlbumAnalyzer(QMainWindow):
         find_action.setShortcut("Ctrl+F")
         find_action.triggered.connect(self.show_search_bar)
         self.edit_menu.addAction(find_action)
+
+        # Add 'Submit Genre' action to 'Edit' menu
+        submit_genre_action = QAction("Submit Genre", self)
+        submit_genre_action.triggered.connect(self.open_genre_submit_dialog)
+        self.edit_menu.addAction(submit_genre_action)
 
     def show_search_bar(self):
         if not hasattr(self, 'search_widget'):
@@ -1792,6 +1797,10 @@ class SpotifyAlbumAnalyzer(QMainWindow):
         self.update_window_title()
 
         logging.info(f"Manually added album '{album}' by '{artist}' with release date '{release_date_display}'")
+
+    def open_genre_submit_dialog(self):
+        dialog = GenreSubmitDialog(self)
+        dialog.exec()
 
 if __name__ == "__main__":
     print("Starting application...")


### PR DESCRIPTION
Add a new "Submit Genre" option to the 'Edit' menu and implement genre submission functionality.

* **main.py**
  - Import `GenreSubmitDialog` from `dialogs.py`.
  - Add a new action "Submit Genre" to the 'Edit' menu.
  - Connect the "Submit Genre" action to a new method `open_genre_submit_dialog`.
  - Implement the `open_genre_submit_dialog` method to open `GenreSubmitDialog`.

* **dialogs.py**
  - Import necessary modules for email functionality.
  - Add a new class `GenreSubmitDialog` for genre submission.
  - Implement the `GenreSubmitDialog` class with a form to input genre names.
  - Add functionality to submit the genre names as an email to magnus+genre@overli.dev.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/magnusoverli/SuShe/pull/14?shareId=d3ccb6a8-a7ce-473c-b2fa-935d73f6ca8e).