### PR TITLE
Fix menubar to use full width and adjust color

### DIFF
--- a/menu_bar.py
+++ b/menu_bar.py
@@ -7,6 +7,7 @@ class MenuBar:
 
     def setup_menu_bar(self):
         bar = self.main_window.menuBar()
+        bar.setFixedWidth(self.main_window.width())
 
         file_menu = bar.addMenu("File")
         

--- a/style.qss
+++ b/style.qss
@@ -114,37 +114,37 @@ QLineEdit {
 
 /* QMenuBar Styles */
 QMenuBar {
-    background-color: #4A4A4C;
+    background-color: #5A5A5C;
     color: white;
     border: 1px solid #555;
     width: 100%;
 }
 
 QMenuBar::item {
-    background-color: #4A4A4C;
+    background-color: #5A5A5C;
     color: white;
 }
 
 QMenuBar::item:selected { /* when selected using mouse or keyboard */
-    background-color: #A0A0A0;
+    background-color: #B0B0B0;
     border-radius: 5px;
 }
 
 /* QMenu Styles */
 QMenu {
-    background-color: #4A4A4C;
+    background-color: #5A5A5C;
     color: white;
     border: 1px solid #555;
 }
 
 QMenu::item {
-    background-color: #4A4A4C;
+    background-color: #5A5A5C;
     color: white;
     padding: 4px 20px; /* Adjusted padding: vertical | horizontal */
 }
 
 QMenu::item:selected { /* when hovered over */
-    background-color: #A0A0A0;
+    background-color: #B0B0B0;
     border-radius: 5px;
 }
 

--- a/style.qss
+++ b/style.qss
@@ -114,13 +114,14 @@ QLineEdit {
 
 /* QMenuBar Styles */
 QMenuBar {
-    background-color: #3A3A3C;
+    background-color: #4A4A4C;
     color: white;
     border: 1px solid #555;
+    width: 100%;
 }
 
 QMenuBar::item {
-    background-color: #3A3A3C;
+    background-color: #4A4A4C;
     color: white;
 }
 
@@ -131,13 +132,13 @@ QMenuBar::item:selected { /* when selected using mouse or keyboard */
 
 /* QMenu Styles */
 QMenu {
-    background-color: #3A3A3C;
+    background-color: #4A4A4C;
     color: white;
     border: 1px solid #555;
 }
 
 QMenu::item {
-    background-color: #3A3A3C;
+    background-color: #4A4A4C;
     color: white;
     padding: 4px 20px; /* Adjusted padding: vertical | horizontal */
 }


### PR DESCRIPTION
Update menubar implementation to utilize full width of the main window and adjust styling.

* Set the width of the `QMenuBar` to match the main window width in `menu_bar.py`.
* Change the background color of the menubar and its menus to a slightly brighter tone in `style.qss`.
* Add a style rule to set the width of the `QMenuBar` to 100% in `style.qss`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/magnusoverli/SuShe/pull/32?shareId=e676475d-653a-4b91-bab3-63a797a0ade5).